### PR TITLE
Fix release workflow failures across iOS, Windows, and MacCatalyst

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ env:
   # ____MacCatalyst_______________________________________
   APPLE_DEV_ID_APP_CERT_NAME: "Developer ID Application: Lancelot Software, LLC (L65255N3F7)"
   APPLE_DEV_ID_INSTALLER_CERT_NAME: "Developer ID Installer: Lancelot Software, LLC (L65255N3F7)"
-  MAC_APP_BUNDLE_PATH: "src/XkcdViewer.Maui/bin/Release/net10.0-maccatalyst/XkcdViewer.app"
+  MAC_APP_BUNDLE_PATH: "src/XkcdViewer.Maui/bin/Release/net10.0-maccatalyst/publish/XkcdViewer.Maui.app"
   MAC_ARTIFACTS_PATH: "artifacts/maccatalyst"
   # ____iOS______________________________________________ (also check matrix vars)
   APPLE_APP_ID: "com.lancelotsoftware.xkcdViewer"
@@ -220,8 +220,9 @@ jobs:
           '-c', 'Release'
           '-f', '${{env.NET_TFM}}-windows10.0.22621.0'
           '-p:Platform=${{matrix.platform}}'
+          '-p:PlatformTarget=${{matrix.platform}}'
           '-p:AppxPackageBuildPlatform=${{matrix.platform}}'
-          '-p:RuntimeIdentifierOverride=${{matrix.runtime_id}}'
+          '-p:RuntimeIdentifier=${{matrix.runtime_id}}'
           '-p:GenerateAppxPackageOnBuild=true'
           '-p:AppxPackageSigningEnabled=false'
           '-p:UapAppxPackageBuildMode=SideloadOnly'
@@ -376,12 +377,33 @@ jobs:
       - name: Build Maui WinUI project
         run: dotnet publish ${{env.PROJECT_PATH}} -c Release -f ${{env.NET_TFM}}-windows10.0.22621.0 -p:AppxPackageSigningEnabled=false -p:AppxSymbolPackageEnabled=false -p:UapAppxPackageBuildMode=StoreUpload -p:AppxBundle=Always "-p:AppxBundlePlatforms=x64|arm64" -p:PlatformTarget=AnyCPU
 
+      - name: Locate Store package
+        id: store-package
+        run: |
+          $appPackagesRoot = "src\${{env.PROJECT_DIRECTORY}}\AppPackages"
+          $candidate = Get-ChildItem -Path $appPackagesRoot -Filter *.msixupload -Recurse -ErrorAction SilentlyContinue |
+            Sort-Object LastWriteTime -Descending |
+            Select-Object -First 1
+
+          if ($null -eq $candidate) {
+            $candidate = Get-ChildItem -Path $appPackagesRoot -Filter *.msixbundle -Recurse -ErrorAction SilentlyContinue |
+              Sort-Object LastWriteTime -Descending |
+              Select-Object -First 1
+          }
+
+          if ($null -eq $candidate) {
+            throw "No .msixupload or .msixbundle was produced under $appPackagesRoot"
+          }
+
+          Write-Host "Using store package: $($candidate.FullName)"
+          echo "PACKAGE_PATH=$($candidate.FullName)" >> $env:GITHUB_OUTPUT
+
       - name: Publish build artifacts
         uses: actions/upload-artifact@v7
         id: upload-artifacts
         with:     
           name: "${{env.APP_NAME}}_v${{needs.shared-resources.outputs.app_version}}_storeupload-windows"
-          path: "**/*.msixupload"
+          path: ${{steps.store-package.outputs.PACKAGE_PATH}}
           if-no-files-found: error
           retention-days: 60
 
@@ -623,123 +645,7 @@ jobs:
           retention-days: 30
 
 
-  # ********************************************************************************** #
-  #                                        iOS                                         #
-  # ********************************************************************************** #
-  ios:
-    name: Build iOS (${{matrix.distribution_name}})
-    runs-on: macos-26
-    needs: shared-resources
-    if: ${{ success() && needs.shared-resources.outputs.app_version != '' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - distribution_name: Store Upload IPA
-            artifact_suffix: storeupload-ios
-            provisioning_profile: "xkcdViewer_AppStore_Distribution"
-            provisioning_profile_type: IOS_APP_STORE
-            rid: ios-arm64
-          - distribution_name: Ad Hoc Sideload IPA
-            artifact_suffix: sideload-ios
-            provisioning_profile: "xkcdViewer_AdHoc_Distribution"
-            provisioning_profile_type: IOS_APP_ADHOC
-            rid: ios-arm64
-    env:
-      APPLE_PROV_PROFILE: ${{matrix.provisioning_profile}}
-      APPLE_PROV_PROFILE_TYPE: ${{matrix.provisioning_profile_type}}
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: ${{env.XCODE_VERSION}}
-
-      - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: ${{env.SDK_VERSION}}
-
-      - name: Install MAUI Workloads
-        run: dotnet workload install maui --source https://api.nuget.org/v3/index.json
-
-      - name: Set Telerik NuGet Credentials
-        run: dotnet nuget update source 'Telerik' -s 'https://nuget.telerik.com/v3/index.json' -u 'api-key' -p "${{secrets.TELERIK_NUGET_KEY}}" --configfile '${{env.NUGET_CONFIG_PATH}}' --store-password-in-clear-text
-
-      - name: Restore NuGet packages
-        run: dotnet restore ${{env.PROJECT_PATH}} --configfile ${{env.NUGET_CONFIG_PATH}}
-
-      # Docs https://github.com/Apple-Actions/import-codesign-certs
-      - name: Import Code-Signing Certificates
-        uses: Apple-Actions/import-codesign-certs@v7
-        with:
-          p12-file-base64: "${{secrets.APPLE_DISTRIBUTION_CERTIFICATE_BASE64}}"
-          p12-password: "${{secrets.APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD}}"
-
-      # Docs https://github.com/Apple-Actions/download-provisioning-profiles
-      - id: provisioning-profiles
-        uses: Apple-Actions/download-provisioning-profiles@v6
-        with:
-          profile-type: "${{env.APPLE_PROV_PROFILE_TYPE}}"
-          bundle-id: "${{env.APPLE_APP_ID}}"
-          issuer-id: "${{secrets.APPSTORE_API_ISSUER_ID}}"
-          api-key-id: "${{secrets.APPSTORE_API_KEY_ID}}"
-          api-private-key: "${{secrets.APPSTORE_API_PRIVATE_KEY}}"
-
-      - name: Verify provisioning profile
-        run: |
-          $profiles = '${{steps.provisioning-profiles.outputs.profiles}}' | ConvertFrom-Json
-          $profile = $profiles | Where-Object { $_.name -eq $env:APPLE_PROV_PROFILE -and $_.type -eq $env:APPLE_PROV_PROFILE_TYPE } | Select-Object -First 1
-
-          if ($null -eq $profile) {
-            $profiles | Format-Table -AutoSize | Out-String | Write-Host
-            throw "Provisioning profile '$env:APPLE_PROV_PROFILE' with type '$env:APPLE_PROV_PROFILE_TYPE' was not downloaded."
-          }
-
-      - name: Verify iOS signing identity is available
-        shell: bash
-        run: |
-          set -euo pipefail
-          security find-identity -v -p codesigning
-          if ! security find-identity -v -p codesigning | grep -F "Apple Distribution" >/dev/null; then
-            echo "Missing Apple Distribution identity"
-            exit 1
-          fi
-
-      # Docs https://learn.microsoft.com/en-us/dotnet/maui/ios/deployment/publish-cli?view=net-maui-9.0
-      - name: Publish MAUI iOS IPA
-        run: |
-          # Query the actual signing identity to avoid comma parsing issues
-          $identityOutput = security find-identity -v -p codesigning | Select-String "Apple Distribution"
-          if (-not $identityOutput) { throw "No Apple Distribution identity found in keychain" }
-          $codesignKey = [regex]::Match($identityOutput.Line, '"(?<name>Apple Distribution:[^"]+)"').Groups['name'].Value
-          if (-not $codesignKey) { throw "Could not parse Apple Distribution identity from keychain output" }
-          Write-Host "Using codesign key: $codesignKey"
-          $quotedCodesignKey = '"' + $codesignKey + '"'
-          
-          $publishArgs = @(
-            'publish'
-            '${{env.PROJECT_PATH}}'
-            '-f', '${{env.NET_TFM}}-ios'
-            '-c', 'Release'
-            '-p:ArchiveOnBuild=true'
-            '-p:RuntimeIdentifier=${{matrix.rid}}'
-            '-p:MtouchLink=SdkOnly'
-            '-p:ApplicationId=${{env.APPLE_APP_ID}}'
-            '-p:ApplicationVersion=${{needs.shared-resources.outputs.app_version}}'
-            '-p:CodesignProvision=${{env.APPLE_PROV_PROFILE}}'
-            "-p:CodesignKey=$quotedCodesignKey"
-          )
-          & dotnet @publishArgs
-          if ($LASTEXITCODE -ne 0) { throw "dotnet publish failed with exit code $LASTEXITCODE" }
-
-      - name: Publish iOS build artifacts
-        uses: actions/upload-artifact@v7
-        with:     
-          name: "${{env.APP_NAME}}_v${{needs.shared-resources.outputs.app_version}}_${{matrix.artifact_suffix}}"
-          path: "src/${{env.PROJECT_DIRECTORY}}/bin/Release/${{env.NET_TFM}}-ios/${{matrix.rid}}/publish/*.ipa"
-          if-no-files-found: error
-          retention-days: 60
+  # iOS packaging is temporarily disabled while provisioning profiles are unavailable.
 
 
   # ********************************************************************************** #
@@ -748,7 +654,7 @@ jobs:
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [shared-resources, android, windows-sideload-packages, windows-generate-msixbundle, windows-store, maccatalyst, ios]
+    needs: [shared-resources, android, windows-sideload-packages, windows-generate-msixbundle, windows-store, maccatalyst]
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v8
@@ -779,15 +685,10 @@ jobs:
 
           # Windows Store upload
           find "release-artifacts/${PREFIX}_storeupload-windows" -name "*.msixupload" -exec cp {} "release-upload/${PREFIX}_msstore.msixupload" \;
+          find "release-artifacts/${PREFIX}_storeupload-windows" -name "*.msixbundle" -exec cp {} "release-upload/${PREFIX}_msstore.msixbundle" \;
 
           # MacCatalyst pkg
           cp "release-artifacts/${PREFIX}_signed-maccatalyst/${{env.APP_NAME}}-MacCatalyst-Release-signed.pkg" "release-upload/${PREFIX}_mac.pkg";
-
-          # iOS Store IPA
-          find "release-artifacts/${PREFIX}_storeupload-ios" -name "*.ipa" -exec cp {} "release-upload/${PREFIX}_ios-store.ipa" \;
-
-          # iOS Ad Hoc sideload IPA
-          find "release-artifacts/${PREFIX}_sideload-ios" -name "*.ipa" -exec cp {} "release-upload/${PREFIX}_ios-sideload.ipa" \;
 
           echo "Files prepared for release:"
           ls -lh release-upload/


### PR DESCRIPTION
The release workflow had multiple blocking failures in issue #13, preventing a successful end-to-end release run. This updates the workflow so packaging steps align with actual build outputs and removes a known-broken path temporarily.

## What changed
- Temporarily removed iOS packaging from this workflow because active provisioning profiles are currently unavailable.
- Fixed Windows sideload ARM64 publish settings by aligning `PlatformTarget` and `RuntimeIdentifier` to avoid NETSDK1032 mismatches.
- Added explicit Windows Store package discovery to upload the actual generated artifact (`.msixupload` or fallback `.msixbundle`) instead of relying on a broad glob that returned no files.
- Corrected MacCatalyst app bundle path to the publish output used by the signing/notarization steps.
- Updated release aggregation wiring to match the new job/artifact set (including iOS removal and optional store `.msixbundle` pickup).

## Notes
- iOS is intentionally temporary-disabled in this workflow and should be re-enabled once provisioning profiles are in place.

Fixes: #13